### PR TITLE
improve .find_or_create_by_name tests

### DIFF
--- a/spec/song_class_methods_spec.rb
+++ b/spec/song_class_methods_spec.rb
@@ -38,17 +38,26 @@ describe "Song Class Methods" do
   end
 
   describe '.find_or_create_by_name' do
-    it 'creates a new song if one doesn\'t already exist' do
-      song_1 = Song.find_or_create_by_name("Blank Space")
-      expect(song_1.name).to eq("Blank Space")
+    it 'invokes .find_by_name and .create_by_name instead of repeating code' do
+      expect(Song).to receive(:find_by_name).at_least(1).times
+      expect(Song).to receive(:create_by_name).at_least(1).times
+
+      Song.find_or_create_by_name("Alison")
+    end
+
+    it 'returns the existing Song object (doesn\'t create a new one) when provided the title of an existing Song' do
+      song_1 = Song.find_or_create_by_name("Sometimes")
+      song_2 = Song.find_or_create_by_name("Sometimes")
+
+      expect(song_1).to eq(song_2)
     end
     
-    it 'finds song by name if song has already been created' do
-      song_1 = Song.find_or_create_by_name("Blank Space")
-      song_2 = Song.find_or_create_by_name("Blank Space")
-      expect(song_1).to be_a(Song)
-      expect(song_2).to be_a(Song)
-      expect(song_1.name).to eq(song_2.name)
+    it 'creates a new Song object with the provided title if one doesn\'t already exist' do
+      blank_space = Song.find_by_name("Blank Space")
+      expect(blank_space).to be(nil)
+
+      blank_space = Song.find_or_create_by_name("Blank Space")
+      expect(blank_space.name).to eq("Blank Space")
     end
   end
 


### PR DESCRIPTION
* current tests don't properly check that a new Song object isn't created if one already exists
* new tests check that students are keeping their code DRY by calling `.find_by_name` and `.create_by_name` within `.find_or_create_by_name`

cc: @aturkewi @cjbrock 